### PR TITLE
Handle non-1D energy arrays in EAS loader

### DIFF
--- a/src/insitu_spex/eas_data_load.py
+++ b/src/insitu_spex/eas_data_load.py
@@ -285,7 +285,12 @@ def EAS_data_load(date_for_spec,tstart,tend,epd_xyz_sectors,low_e_cutoff=0.8):
     
     #print(count_curve_raw.shape)
     
+    
     combo_energies=np.array(energies)
+    
+    #sometimes energy array has different shape: to ensure this is not an issue
+    if len(combo_energies.shape) != 1:
+        combo_energies=combo_energies[0]
     
     #breakpoint()
     #%%sawtooth correction, only keep even index bins


### PR DESCRIPTION
Normalize the energies array to ensure combo_energies is 1D before downstream use. Adds a check for arrays with extra dimensions and extracts the first row when len(combo_energies.shape) != 1, preventing shape-related errors during processing. Includes a clarifying comment; no other logic changes.